### PR TITLE
Hotfix/old events importer fixes

### DIFF
--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -332,24 +332,27 @@ class TurkuOriginalImporter(Importer):
 
             event_image_ext_url = ''
             image_license = ''
-            event_image_license = self.event_only_license
+            #event_image_license = self.event_only_license
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
-                event_image_ext_url = event_image_url
+
+                
+                def eimglc(ext_url, img_lc):
+                    eventItem['images'] = [{
+                    'url': ext_url,
+                    'license': img_lc,
+                    }]
 
                 #event_image_license 1 or 2 (1 is 'event_only' and 2 is 'cc_by' in Linked Events) NOTE! CHECK VALUES IN DRUPAL!
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
-                        event_image_license = self.event_only_license
-                    elif image_license == '2':
                         event_image_license = self.cc_by_license
-
-                eventItem['images'] = [{
-                    'url': event_image_ext_url,
-                    'license': event_image_license,
-                    }]
+                        eimglc(event_image_ext_url, event_image_license)
+                    #if image_license == '2':
+                        # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
+                        #event_image_license = self.event_only_license
 
             def set_attr(field_name, val):
                 if field_name in eventItem:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -332,7 +332,7 @@ class TurkuOriginalImporter(Importer):
 
             event_image_ext_url = ''
             image_license = ''
-            #event_image_license = self.event_only_license
+            event_image_license = self.event_only_license
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
@@ -352,7 +352,7 @@ class TurkuOriginalImporter(Importer):
                         eimglc(event_image_ext_url, event_image_license)
                     #if image_license == '2':
                         # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
-                        #event_image_license = self.event_only_license
+                    #    event_image_license = self.event_only_license
 
             def set_attr(field_name, val):
                 if field_name in eventItem:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -332,27 +332,24 @@ class TurkuOriginalImporter(Importer):
 
             event_image_ext_url = ''
             image_license = ''
-            #event_image_license = self.event_only_license
+            event_image_license = self.event_only_license
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
-
-                
-                def eimglc(ext_url, img_lc):
-                    eventItem['images'] = [{
-                    'url': ext_url,
-                    'license': img_lc,
-                    }]
+                event_image_ext_url = event_image_url
 
                 #event_image_license 1 or 2 (1 is 'event_only' and 2 is 'cc_by' in Linked Events) NOTE! CHECK VALUES IN DRUPAL!
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
+                        event_image_license = self.event_only_license
+                    elif image_license == '2':
                         event_image_license = self.cc_by_license
-                        eimglc(event_image_ext_url, event_image_license)
-                    #if image_license == '2':
-                        # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
-                        #event_image_license = self.event_only_license
+
+                eventItem['images'] = [{
+                    'url': event_image_ext_url,
+                    'license': event_image_license,
+                    }]
 
             def set_attr(field_name, val):
                 if field_name in eventItem:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -350,7 +350,7 @@ class TurkuOriginalImporter(Importer):
                         event_image_ext_url = event_image_url
                         event_image_license = self.cc_by_license
                         eimglc(event_image_ext_url, event_image_license)
-                    if image_license == '2':
+                    #if image_license == '2':
                         # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
                         #event_image_license = self.event_only_license
 

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -332,32 +332,23 @@ class TurkuOriginalImporter(Importer):
 
             event_image_ext_url = ''
             image_license = ''
-            event_image_license = self.event_only_license
+            #event_image_license = self.event_only_license
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
-
-                print("pic")
-                #def eimglc(ext_url, img_lc):
-                #    eventItem['images'] = [{
-                #    'url': ext_url,
-                #    'license': img_lc,
-                #    }]
 
                 #event_image_license 1 or 2 (1 is 'event_only' and 2 is 'cc_by' in Linked Events) NOTE! CHECK VALUES IN DRUPAL!
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
                         event_image_license = self.cc_by_license
-                        #eimglc(event_image_ext_url, event_image_license)
-                        print("evenItem adding image url and license")
                         eventItem['images'] = [{
                         'url': event_image_url,
                         'license': event_image_license,
                         }]
                     #if image_license == '2':
                         # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
-                    #    event_image_license = self.event_only_license
+                        #event_image_license = self.event_only_license
 
             def set_attr(field_name, val):
                 if field_name in eventItem:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -306,8 +306,12 @@ class TurkuOriginalImporter(Importer):
                 "en": bleach.clean(self.with_value(eventTku, 'lead_paragraph_markup_en', ''),   tags=[],   strip=True)
             }
 
-            eventItem['provider'] = {"fi": 'Turku', "sv": 'Åbo', "en": 'Turku'}
-
+            if eventTku['event_organizer']:
+                eo = eventTku['event_organizer']
+                eventItem['provider'] = {"fi": eo, "sv": eo, "en": eo}
+            else:
+                eventItem['provider'] = {"fi": 'Turku', "sv": 'Åbo', "en": 'Turku'}
+                
             location_extra_info = ''
 
             if self.with_value(eventTku, 'address_extension', ''):

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -338,18 +338,23 @@ class TurkuOriginalImporter(Importer):
             if event_image_url:
 
                 print("pic")
-                def eimglc(ext_url, img_lc):
-                    eventItem['images'] = [{
-                    'url': ext_url,
-                    'license': img_lc,
-                    }]
+                #def eimglc(ext_url, img_lc):
+                #    eventItem['images'] = [{
+                #    'url': ext_url,
+                #    'license': img_lc,
+                #    }]
 
                 #event_image_license 1 or 2 (1 is 'event_only' and 2 is 'cc_by' in Linked Events) NOTE! CHECK VALUES IN DRUPAL!
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
                         event_image_license = self.cc_by_license
-                        eimglc(event_image_ext_url, event_image_license)
+                        #eimglc(event_image_ext_url, event_image_license)
+                        print("evenItem adding image url and license")
+                        eventItem['images'] = [{
+                        'url': event_image_url,
+                        'license': event_image_license,
+                        }]
                     #if image_license == '2':
                         # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
                     #    event_image_license = self.event_only_license

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -337,7 +337,7 @@ class TurkuOriginalImporter(Importer):
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
 
-                
+                print("pic")
                 def eimglc(ext_url, img_lc):
                     eventItem['images'] = [{
                     'url': ext_url,

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -311,7 +311,7 @@ class TurkuOriginalImporter(Importer):
                 eventItem['provider'] = {"fi": eo, "sv": eo, "en": eo}
             else:
                 eventItem['provider'] = {"fi": 'Turku', "sv": 'Åbo', "en": 'Turku'}
-                
+
             location_extra_info = ''
 
             if self.with_value(eventTku, 'address_extension', ''):
@@ -336,20 +336,23 @@ class TurkuOriginalImporter(Importer):
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
-                event_image_ext_url = event_image_url
+
+                def eimglc(ext_url, img_lc):
+                    eventItem['images'] = [{
+                    'url': ext_url,
+                    'license': img_lc,
+                    }]
 
                 #event_image_license 1 or 2 (1 is 'event_only' and 2 is 'cc_by' in Linked Events) NOTE! CHECK VALUES IN DRUPAL!
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
-                        event_image_license = self.event_only_license
-                    elif image_license == '2':
+                        event_image_ext_url = event_image_url
                         event_image_license = self.cc_by_license
-
-                eventItem['images'] = [{
-                    'url': event_image_ext_url,
-                    'license': event_image_license,
-                    }]
+                        eimglc(event_image_ext_url, event_image_license)
+                    if image_license == '2':
+                        # -> We don't import nor necessarily need to mark the publication banned images, hence why this is commented out until further use.
+                        #event_image_license = self.event_only_license
 
             def set_attr(field_name, val):
                 if field_name in eventItem:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -332,11 +332,12 @@ class TurkuOriginalImporter(Importer):
 
             event_image_ext_url = ''
             image_license = ''
-            event_image_license = self.event_only_license
+            #event_image_license = self.event_only_license
 
             #NOTE! Events image is not usable in Helmet must use this Lippupiste.py way to do it         
             if event_image_url:
 
+                
                 def eimglc(ext_url, img_lc):
                     eventItem['images'] = [{
                     'url': ext_url,
@@ -347,7 +348,6 @@ class TurkuOriginalImporter(Importer):
                 if eventTku['event_image_license']:
                     image_license = eventTku['event_image_license']
                     if image_license == '1':
-                        event_image_ext_url = event_image_url
                         event_image_license = self.cc_by_license
                         eimglc(event_image_ext_url, event_image_license)
                     #if image_license == '2':


### PR DESCRIPTION
Event organizer field added from the Drupal JSON as a provider for the events.
Event image license changes; we no longer import images that are publication banned from the original event calendar/Drupal JSON.

