### PR TITLE
Update turku_old_events.py

### DIFF
--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -637,7 +637,7 @@ class TurkuOriginalImporter(Importer):
             if event_type == "m":
                 evItem['super_event_type'] = Event.SuperEventType.RECURRING
             if event_type == "c" or event_type == "s":
-                evItem['super_event_type'] = ""
+                evItem['super_event_type'] = None
 
             return evItem
 


### PR DESCRIPTION
Miniscule change to the importer so the events without a super event type are considered Null/None instead of empty as in whitespace.