### PR TITLE
Base.py Multilevel Field NodeName Parsing Removal

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -223,11 +223,11 @@ class Importer(object):
     def _save_field(self, obj, obj_field_name, info,
                     info_field_name, max_length=None):
 
-        if info and info_field_name:
+        if info[info_field_name]:
             val = clean_text(info[info_field_name])
         else:
             val = None
-        if (max_length, val) and len(val) > max_length:
+        if max_length and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
         self._set_field(obj, obj_field_name, val)
@@ -246,12 +246,12 @@ class Importer(object):
     def _save_field_multilevel(self, obj, obj_field_name, info,
                                info_field_name, max_length=None, nodeNames=[], lang=''):
         # Multilevel is used by tpr importer but does not use nodename or max length.
-        # We have retained some of these parameters & statements for future use if necessary.
+        # We have retained some of these parameters for future use.
         if info[info_field_name]:
             val = clean_text(info[info_field_name][lang])
         else:
             val = None
-        if (max_length, val) and len(val) > max_length:
+        if max_length and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
 

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -222,23 +222,19 @@ class Importer(object):
 
     def _save_field(self, obj, obj_field_name, info,
                     info_field_name, max_length=None):
-        
-        if type(info[info_field_name]) == None:
-            print('Type none: ', info_field_name, ': ', info[info_field_name])
-        else:            
-            # atm only used by place importers, do some extra cleaning and validation before setting value
-            if info_field_name in info:
-                val = clean_text(info[info_field_name])
-            else:
-                val = None
-            if max_length and val and len(val) > max_length:
-                self.logger.warning("%s: field %s too long" % (obj, info_field_name))
-                val = None
-            self._set_field(obj, obj_field_name, val)
+
+        if info[info_field_name]:
+            val = clean_text(info[info_field_name])
+        else:
+            val = None
+        if max_length and len(val) > max_length:
+            self.logger.warning("%s: field %s too long" % (obj, info_field_name))
+            val = None
+        self._set_field(obj, obj_field_name, val)
 
     def _save_translated_field(self, obj, obj_field_name, info,
                                info_field_name, max_length=None):
-        # atm only used by place importers, do some extra cleaning and validation before setting value
+
         for lang in self.supported_languages:
             key = '%s_%s' % (info_field_name, lang)
             obj_key = '%s_%s' % (obj_field_name, lang)
@@ -247,70 +243,32 @@ class Importer(object):
             if lang == 'fi':
                 self._save_field(obj, obj_field_name, info, key, max_length)
 
-    # multilevel (3 step max) json version for turku 
     def _save_field_multilevel(self, obj, obj_field_name, info,
-                     info_field_name, max_length=None, nodeNames=[], lang=''):
-        # atm only used by place importers, do some extra cleaning and validation before setting value
-        # multilevel (6 step max) json version for turku 
-        #print ('lang: ', lang) 
-        if info_field_name in info:
-            if len(nodeNames) == 0 and lang == '':
-                #print ('LEVEL1 no lang: ', info[info_field_name])
-                val = clean_text(info[info_field_name])
-            elif len(nodeNames) == 0:
-                #print ('LEVEL1: ', info[info_field_name][lang], ' lang: ', lang)
-                val = clean_text(info[info_field_name][lang])
-            if len(nodeNames) == 1 and lang == '':                
-                #print ('LEVEL2 CCC no lang: ', info[info_field_name][nodeNames])
-                val = clean_text(info[info_field_name][nodeNames[0]])
-            elif len(nodeNames) == 1:
-                #print ('LEVEL2: ', info[info_field_name][nodeNames[0]][lang] , ' lang: ', lang) 
-                val = clean_text(info[info_field_name][nodeNames[0]][lang])
-            if len(nodeNames) == 2 and lang == '':
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]])
-            elif len(nodeNames) == 2:
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][lang])
-            if len(nodeNames) == 3 and lang == '':
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]])
-            elif len(nodeNames) == 3:
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]][lang])
-            if len(nodeNames) == 4 and lang == '': 
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]][nodeNames[3]])    
-            elif len(nodeNames) == 4: 
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]][nodeNames[3]][lang])
-            if len(nodeNames) == 5 and lang == '': 
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]][nodeNames[3]][nodeNames[4]])
-            elif len(nodeNames) == 5: 
-                val = clean_text(info[info_field_name][nodeNames[0]][nodeNames[1]][nodeNames[2]][nodeNames[3]][nodeNames[4]][lang])
-            if len(nodeNames) > 5:
-                self.logger.warning("%s: field %s Check level of nodes! Max main level + 5 + lang" % (obj, info_field_name))     
+                               info_field_name, max_length=None, nodeNames=[], lang=''):
+        # Multilevel is used by tpr importer but does not use nodename or max length.
+        # We have retained some of these parameters & statements for future use if necessary.
+        if info[info_field_name]:
+            val = clean_text(info[info_field_name][lang])
         else:
             val = None
-        if max_length and val and len(val) > max_length:
+        if max_length and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
+
         self._set_field(obj, obj_field_name, val)
 
-    # multilevel (3 step max) json version for turku 
     def _save_translated_field_multilevel(self, obj, obj_field_name, info,
-                               info_field_name, max_length=None, nodeNames=[]):
-        # atm only used by place importers, do some extra cleaning and validation before setting value
-        # multilevel (6 step max) json version for turku 
-        for lang in self.supported_languages:
-            #key = '%s_%s' % (info_field_name, lang)
+                                          info_field_name, max_length=None, nodeNames=[]):
 
+        for lang in self.supported_languages:
             obj_key = '%s_%s' % (obj_field_name, lang)
-            #print ('AAAA obj_key saving on field: ', obj_key)
-            #print ('BBBB and this language: ', lang)
 
             self._save_field_multilevel(obj, obj_key, info, info_field_name, max_length, nodeNames, lang)
             if lang == 'fi':
                 self._save_field_multilevel(obj, obj_field_name, info, info_field_name, max_length, nodeNames, lang)
-            
-            #self.logger.warning("%s: field %s Check level of nodes!" % (obj, info_field_name)) 
 
     def _update_fields(self, obj, info, skip_fields):
-        # all non-place importers use this method, automatically takes care of translated fields
+
         obj_fields = list(obj._meta.fields)
         trans_fields = translator.get_options_for_model(type(obj)).fields
         for field_name, lang_fields in trans_fields.items():

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -223,11 +223,11 @@ class Importer(object):
     def _save_field(self, obj, obj_field_name, info,
                     info_field_name, max_length=None):
 
-        if info[info_field_name]:
+        if info and info_field_name:
             val = clean_text(info[info_field_name])
         else:
             val = None
-        if max_length and len(val) > max_length:
+        if (max_length, val) and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
         self._set_field(obj, obj_field_name, val)
@@ -251,7 +251,7 @@ class Importer(object):
             val = clean_text(info[info_field_name][lang])
         else:
             val = None
-        if max_length and len(val) > max_length:
+        if (max_length, val) and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
 

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -223,11 +223,11 @@ class Importer(object):
     def _save_field(self, obj, obj_field_name, info,
                     info_field_name, max_length=None):
 
-        if info[info_field_name]:
+        if info and info_field_name and info[info_field_name]:
             val = clean_text(info[info_field_name])
         else:
             val = None
-        if max_length and len(val) > max_length:
+        if max_length and val and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
         self._set_field(obj, obj_field_name, val)
@@ -247,11 +247,11 @@ class Importer(object):
                                info_field_name, max_length=None, nodeNames=[], lang=''):
         # Multilevel is used by tpr importer but does not use nodename or max length.
         # We have retained some of these parameters for future use.
-        if info[info_field_name]:
+        if info and info_field_name and info[info_field_name]:
             val = clean_text(info[info_field_name][lang])
         else:
             val = None
-        if max_length and len(val) > max_length:
+        if max_length and val and len(val) > max_length:
             self.logger.warning("%s: field %s too long" % (obj, info_field_name))
             val = None
 


### PR DESCRIPTION
Base.py needed the removal of the "NodeName" parsing within the multilevel field function.
Function parameters remain because we might need a future use for them but as for the parsing, we are currently not using it.
The code section for it had to be removed not just because it wasn't being used, but because it was not following the proper code practice methods.