### PR TITLE
TPR importer asynchronous revision.

### DIFF
--- a/events/importer/tpr.py
+++ b/events/importer/tpr.py
@@ -228,12 +228,12 @@ class TprekImporter(Importer):
             queryset = queryset.filter(id=obj_id)
         else:
             logger.info("Fetching all unit pages...")
-            obj_list = async_main() # Optional async_main(True) if you want to log errors.
+            obj_list = async_main()  # Optional async_main(True) if you want to log errors.
             if obj_list:
                 logger.info("Successfully gathered unit data!")
             else:
                 logger.warn("Something went wrong... No unit data was found?")
-
+                return
         syncher = ModelSyncher(queryset, lambda obj: obj.origin_id, delete_func=self.mark_deleted,
                                check_deleted_func=self.check_deleted)
         for idx, infos in enumerate(obj_list, start=1):

--- a/events/importer/tprapi.py
+++ b/events/importer/tprapi.py
@@ -1,12 +1,12 @@
 import asyncio
 import aiohttp
 import logging
+import json
 import sys
 
 # Per module logger
 logger = logging.getLogger(__name__)
 
-content = []
 headers = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -14,48 +14,51 @@ headers = {
 }
 
 
-async def fetch(url, session):
-    response = await session.request(method="GET", url=url, headers=headers)
-    response.raise_for_status()
-    json_response = await response.json()
-    return json_response
+async def fetch(session, url, id):
+    async with session.get(url) as response:
+        data = await response.read()
+        json_response = json.loads(data)
+        result = json_response.get('results', None)
+        if result:
+            return result
+        else:
+            err_result = json_response.get('detail', None)
+            if err_result:
+                raise Exception(
+                    "Palvelukartta unit reported: '%s' for page: %s" % (err_result, id))
+            # If the API ever changes error handling in the future, notify about it.
+            raise Exception(
+                "Palvelukartta unit: '%s' request did not fail, but API parsing was incorrect. API has changed?" % id)
 
 
-async def process_json(json, page_no) -> None:
-    content.append(json['results'])
-
-
-async def main(allow_errors=False):
+async def main(unit_pages=63):
     async with aiohttp.ClientSession() as session:
         tasks = []
-        for page_no in range(1, 100):
-            url = "https://palvelukartta.turku.fi/api/v2/unit/?page=%s" % page_no
-            try:
-                json = await fetch(url, session)
-                tasks.append(process_json(json, page_no))
-            except (
-                aiohttp.ClientError,
-                aiohttp.http_exceptions.HttpProcessingError,
-            ) as err:
-                if allow_errors == True:
-                    # Error handling goes here.
-                    # err.status, err.message etc.
-                    logger.warn('Unit: %s reported: %s' %
-                                (page_no, err.status))
-                else:
-                    pass
-        await asyncio.gather(*tasks)
-    return content
+        for page_no in range(0, unit_pages):
+            URL = 'https://palvelukartta.turku.fi/api/v2/unit/?page=%s' % page_no
+            tasks.append(fetch(session, URL, page_no))
+        try:
+            res = await asyncio.gather(*tasks, return_exceptions=False)
+            return res
+        except Exception as e:
+            logger.warn(e)
+            await asyncio.sleep(1)
 
 
-def async_main(x=None):
+def async_main(retry_count=3):
+    # Currently works in 3.6 Python
     # Works for both 3.6 and 3.7 Python versions.
-    if sys.version_info >= (3, 7, 0):
-        # 3.7+ support.
-        return asyncio.run(main(x))
-    else:
-        # 3.6+ support.
-        futures = [main(x)]
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.wait(futures))
-        return content
+    for connection_retries in range(retry_count):
+        if sys.version_info >= (3, 8, 0):
+            res = asyncio.run(main())
+            if res:
+                return res
+        else:
+            # 3.6+ support.
+            loop = asyncio.get_event_loop()
+            task = loop.create_task(main())
+            a = loop.run_until_complete(task)
+            task.cancel()
+            if a:
+                return a
+    logger.warn("Retry limit exceeded! Giving up...")

--- a/events/importer/tprapi.py
+++ b/events/importer/tprapi.py
@@ -34,7 +34,7 @@ async def fetch(session, url, id):
 async def main(unit_pages=63):
     async with aiohttp.ClientSession() as session:
         tasks = []
-        for page_no in range(0, unit_pages):
+        for page_no in range(1, unit_pages):
             URL = 'https://palvelukartta.turku.fi/api/v2/unit/?page=%s' % page_no
             tasks.append(fetch(session, URL, page_no))
         try:


### PR DESCRIPTION
I had to rewrite the logic for tprapi.py which is in implemented into TPR importer, because the previous version did not import all palvelukartta units due to not handling requests properly. 

I have tested these code changes on my test instance and the new revision seem to work properly.

- Python version 3.6+ possible memory clogging issue fixed. (Coroutine related) tasks get handled properly now by closing when finished.
- text/html Mimetype gets parsed now.
- Python version 3.6+ future removed.
- Now utilizing proper asynchronous methods
- Proper error handling for connection errors and parsing.
- Now has a retry method, so in case the API rejects our requests, we retry N amount of times (3 by default).
- No outside scope lists to append to; works within function scopes.
- Returns instead of giving a syntax error if no data was returned from the API.