### PR TITLE
Sub event type support for Turku old events importer

### DIFF
--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -648,6 +648,7 @@ class TurkuOriginalImporter(Importer):
                                     }
                                 )
                             except Exception as ex:
+                                print("Child saving did not work... ------")
                                 pass
                         except Exception as ex:
                             pass

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -609,6 +609,14 @@ class TurkuOriginalImporter(Importer):
                         try:
                             child = Event.objects.get(origin_id=x['drupal_nid'])
                             mother = Event.objects.get(origin_id=json_event['drupal_nid'])
+
+                            sub_event_type = None
+                            #sub_recurring, sub_umbrella
+                            if mother.super_event_type == "recurring":
+                                sub_event_type = "sub_recurring"
+                            elif mother.super_event_type == "umbrella":
+                                sub_event_type = "sub_umbrella"
+
                             try:
                                 Event.objects.update_or_create(
                                     id=child.id,
@@ -636,6 +644,7 @@ class TurkuOriginalImporter(Importer):
                                         'info_url_sv': mother.info_url_fi,
                                         'info_url_en': mother.info_url_fi,
                                         'super_event': mother
+                                        'sub_event_type': sub_event_type
                                     }
                                 )
                             except Exception as ex:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -610,12 +610,15 @@ class TurkuOriginalImporter(Importer):
                             child = Event.objects.get(origin_id=x['drupal_nid'])
                             mother = Event.objects.get(origin_id=json_event['drupal_nid'])
 
+                            logger.info("savee lapsi tapahtumaa just nyt.")
+
                             sub_event_type = None
                             #sub_recurring, sub_umbrella
                             if mother.super_event_type == "recurring":
                                 sub_event_type = "sub_recurring"
                             elif mother.super_event_type == "umbrella":
                                 sub_event_type = "sub_umbrella"
+
 
                             try:
                                 Event.objects.update_or_create(
@@ -648,7 +651,7 @@ class TurkuOriginalImporter(Importer):
                                     }
                                 )
                             except Exception as ex:
-                                print("Child saving did not work... ------")
+                                logger.info("error saving child event: ", ex)
                                 pass
                         except Exception as ex:
                             pass

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -643,8 +643,8 @@ class TurkuOriginalImporter(Importer):
                                         'info_url_fi': mother.info_url_fi,
                                         'info_url_sv': mother.info_url_fi,
                                         'info_url_en': mother.info_url_fi,
-                                        'super_event': mother
-                                        'sub_event_type': sub_event_type
+                                        'super_event': mother,
+                                        'sub_event_type': sub_event_type,
                                     }
                                 )
                             except Exception as ex:

--- a/events/importer/turku_old_events.py
+++ b/events/importer/turku_old_events.py
@@ -610,15 +610,12 @@ class TurkuOriginalImporter(Importer):
                             child = Event.objects.get(origin_id=x['drupal_nid'])
                             mother = Event.objects.get(origin_id=json_event['drupal_nid'])
 
-                            logger.info("savee lapsi tapahtumaa just nyt.")
-
                             sub_event_type = None
                             #sub_recurring, sub_umbrella
                             if mother.super_event_type == "recurring":
                                 sub_event_type = "sub_recurring"
                             elif mother.super_event_type == "umbrella":
                                 sub_event_type = "sub_umbrella"
-
 
                             try:
                                 Event.objects.update_or_create(
@@ -651,7 +648,6 @@ class TurkuOriginalImporter(Importer):
                                     }
                                 )
                             except Exception as ex:
-                                logger.info("error saving child event: ", ex)
                                 pass
                         except Exception as ex:
                             pass


### PR DESCRIPTION
Due to our newest addition on how child events inherit their mothers super event type into the childs 'sub_event_type' field, our old events importer now supports this feature as well.