### PR TITLE
Hotfix/osoite-coordinate-null-fix

### DIFF
--- a/events/importer/osoite.py
+++ b/events/importer/osoite.py
@@ -132,7 +132,7 @@ class OsoiteImporter(Importer):
 
         position = address_obj.location
         #print("[OSOITE.PY]: ---> POSITION: ", position)
-        position = None
+        #position = None
         obj._changed = True
         if position and obj.position:
             # If the distance is less than 10cm, assume the location
@@ -140,7 +140,7 @@ class OsoiteImporter(Importer):
             assert obj.position.srid == settings.PROJECTION_SRID
             if position.distance(obj.position) < 0.10:
                 position = obj.position
-                position = None
+                #position = None
         if position != obj.position:
             obj._changed = True
             obj._changed_fields.append('position')


### PR DESCRIPTION
# Osoite importer - Reverted NULL conversion changes

## NULL Conversion changes have been reverted due to Coordinate conversion fix in turku.py file.
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Changes
 1. osoite.py
     * NULL change has been fixed due to turku.py coordinate conversion fix from EPSG:3788 to EPSG:4326 (WSG84).
