### PR TITLE
hotfix/django-munigeo-turku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ django-js-asset==1.2.2    # via django-mptt
 django-leaflet==0.26.0    # via -r requirements.in
 django-modeltranslation==0.14.4  # via -r requirements.in
 django-mptt==0.11.0       # via -r requirements.in, django-munigeo, django-orghierarchy
-django-munigeo-turku==0.2.28    # via -r requirements.in
+django-munigeo-turku==0.2.29    # via -r requirements.in
 django-orghierarchy-turku==0.1.27  # via -r requirements.in
 django-parler-rest==2.1   # via django-munigeo
 django-parler==2.0.1      # via django-munigeo, django-parler-rest


### PR DESCRIPTION
# Hotfix to django-munigeo-turku

## Fixed address coordinates conversion.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Changes
 1. requirements.txt 
     * version change to django-munigeo-turku due to turku.py coordinate conversion fix from EPSG:3788 to EPSG:4326 (WSG84).